### PR TITLE
Scanner fixes

### DIFF
--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -44,23 +44,21 @@ where
             }
         }
 
-        if let Some(ch) = self.iter.next() {
-            match ch {
-                '(' => Ok(Token::OpenParen),
-                ')' => Ok(Token::CloseParen),
-                '\'' => Ok(Token::Quote),
+        match self.iter.next() {
+            Some('(') => Ok(Token::OpenParen),
+            Some(')') => Ok(Token::CloseParen),
+            Some('\'') => Ok(Token::Quote),
 
-                // string
-                '"' => self.read_string(),
+            // string
+            Some('"') => self.read_string(),
 
-                // number
-                ch if ch.is_ascii_digit() => self.read_number(ch),
+            // number
+            Some(ch) if ch.is_ascii_digit() => self.read_number(ch),
 
-                // we allow all other characters to be a symbol
-                ch => self.read_symbol(ch),
-            }
-        } else {
-            Err(ScanError::EndOfFile)
+            // we allow all other characters to be a symbol
+            Some(ch) => self.read_symbol(ch),
+
+            None => Err(ScanError::EndOfFile),
         }
     }
 

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -5,7 +5,6 @@ pub enum Token {
     OpenParen,
     CloseParen,
     Quote,
-    Newline,
     Num(f64),
     Str(String),
     Sym(String),
@@ -46,15 +45,6 @@ where
                 '(' => Ok(Token::OpenParen),
                 ')' => Ok(Token::CloseParen),
                 '\'' => Ok(Token::Quote),
-
-                // newline "\r" | "\r\n"
-                '\r' => {
-                    self.iter.next_if(|&ch| ch == '\n');
-                    Ok(Token::Newline)
-                }
-
-                // newline "\n"
-                '\n' => Ok(Token::Newline),
 
                 // string
                 '"' => self.read_string(),


### PR DESCRIPTION
- Rename `Token::Newline`
- Fix whitespace & comment skipping