### PR TITLE
Symbol interning

### DIFF
--- a/src/builtin/mod.rs
+++ b/src/builtin/mod.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 
 use crate::env::Env;
 use crate::eval::{eval, EvalError, EvalResult};
-use crate::expr::{Expr, NIL};
+use crate::expr::{intern, Expr, NIL};
 use crate::list::{cons, List};
 use crate::proc::Proc;
 
@@ -218,7 +218,7 @@ pub fn set(proc_name: &str, args: &List, env: &Rc<Env>) -> EvalResult {
 fn make_syntax_error(proc_name: &str, args: &List) -> EvalError {
     format!(
         "Ill-formed syntax: {}",
-        cons(Expr::Sym(proc_name.into()), args.clone())
+        cons(intern(proc_name), args.clone())
     )
 }
 
@@ -267,7 +267,6 @@ fn make_formal_args(list: &List) -> Result<Vec<String>, EvalError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::expr::shortcuts::sym;
     use crate::macros::list;
 
     #[test]
@@ -275,7 +274,7 @@ mod tests {
         let env = Env::for_unit_test();
 
         // (define name "value")
-        let ret = define("", &list!(sym("name"), "value"), &env);
+        let ret = define("", &list!(intern("name"), "value"), &env);
         assert_eq!(ret, Ok(NIL));
         assert_eq!(env.lookup("name"), Some("value".into()));
     }

--- a/src/builtin/num.rs
+++ b/src/builtin/num.rs
@@ -60,7 +60,7 @@ pub fn is_num(proc_name: &str, args: &List, _env: &Rc<Env>) -> EvalResult {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::expr::shortcuts::num;
+    use crate::expr::test_utils::num;
     use crate::macros::list;
 
     #[test]

--- a/src/builtin/quote.rs
+++ b/src/builtin/quote.rs
@@ -82,7 +82,7 @@ pub fn quasiquote(proc_name: &str, args: &List, env: &Rc<Env>) -> EvalResult {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::expr::shortcuts::sym;
+    use crate::expr::intern;
     use crate::macros::list;
     use crate::proc::Proc;
 
@@ -103,7 +103,7 @@ mod tests {
         // `(0 1 ,x 3) => (0 1 2 3)
         let result = quasiquote(
             "",
-            &list!(list!(0, 1, list!(sym("unquote"), sym("x")), 3)),
+            &list!(list!(0, 1, list!(intern("unquote"), intern("x")), 3)),
             &env,
         );
         assert_eq!(result, Ok(list!(0, 1, 2, 3).into()));
@@ -123,7 +123,11 @@ mod tests {
         // (quasiquote (0 (unquote (+ 1 2)) 4)) => (0 3 4)
         let result = quasiquote(
             "",
-            &list!(list!(0, list!(sym("unquote"), list!(sym("+"), 1, 2)), 4)),
+            &list!(list!(
+                0,
+                list!(intern("unquote"), list!(intern("+"), 1, 2)),
+                4
+            )),
             &env,
         );
         assert_eq!(result, Ok(list!(0, 3, 4).into()));
@@ -145,7 +149,10 @@ mod tests {
             "",
             &list!(list!(
                 0,
-                list!(sym("unquote-splicing"), list!(sym("quote"), list!(1, 2, 3))),
+                list!(
+                    intern("unquote-splicing"),
+                    list!(intern("quote"), list!(1, 2, 3))
+                ),
                 4
             )),
             &env,

--- a/src/env.rs
+++ b/src/env.rs
@@ -146,7 +146,7 @@ impl Drop for Env {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::expr::shortcuts::num;
+    use crate::expr::test_utils::num;
 
     #[test]
     fn test_set() {

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -95,6 +95,23 @@ impl From<bool> for Expr {
     }
 }
 
+/// Interns a string into an `Expr::Sym`.
+///
+/// This function takes a string and converts it into an `Expr::Sym`. The string is
+/// converted into an owned `String` and then wrapped in an `Expr::Sym` variant.
+///
+/// # Examples
+///
+/// ```
+/// use rusp::expr::{intern, Expr};
+///
+/// let symbol = intern("foo");
+/// assert_eq!(symbol, Expr::Sym(String::from("foo")));
+/// ```
+pub fn intern<T: Into<String>>(name: T) -> Expr {
+    Expr::Sym(name.into())
+}
+
 #[cfg(test)]
 pub mod shortcuts {
     use super::Expr;
@@ -102,15 +119,11 @@ pub mod shortcuts {
     pub fn num<T: Into<f64>>(value: T) -> Expr {
         Expr::Num(value.into())
     }
-
-    pub fn sym<T: Into<String>>(name: T) -> Expr {
-        Expr::Sym(name.into())
-    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::shortcuts::{num, sym};
+    use super::shortcuts::num;
     use super::*;
     use crate::macros::list;
 
@@ -134,7 +147,7 @@ mod tests {
 
     #[test]
     fn test_display_sym() {
-        assert_eq!(format!("{}", sym("sym")), "sym");
+        assert_eq!(format!("{}", intern("sym")), "sym");
     }
 
     #[test]
@@ -151,14 +164,14 @@ mod tests {
 
     #[test]
     fn test_display_list_3() {
-        let list = list!(0, "str", sym("sym"));
+        let list = list!(0, "str", intern("sym"));
         assert_eq!(format!("{}", list), r#"(0 "str" sym)"#);
     }
 
     #[test]
     fn test_expr_from_list() {
         assert_eq!(
-            format!("{}", Expr::from(list!(list!(1, 2), 3, 4, sym("abc")))),
+            format!("{}", Expr::from(list!(list!(1, 2), 3, 4, intern("abc")))),
             "((1 2) 3 4 abc)"
         );
     }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -113,7 +113,7 @@ pub fn intern<T: Into<String>>(name: T) -> Expr {
 }
 
 #[cfg(test)]
-pub mod shortcuts {
+pub mod test_utils {
     use super::Expr;
 
     pub fn num<T: Into<f64>>(value: T) -> Expr {
@@ -123,7 +123,7 @@ pub mod shortcuts {
 
 #[cfg(test)]
 mod tests {
-    use super::shortcuts::num;
+    use super::test_utils::num;
     use super::*;
     use crate::macros::list;
 

--- a/src/list.rs
+++ b/src/list.rs
@@ -100,12 +100,13 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::expr::shortcuts::{num, sym};
+    use crate::expr::intern;
+    use crate::expr::shortcuts::num;
     use crate::macros::list;
 
     #[test]
     fn test_display() {
-        let list = list!(1, 2, list!(3, "str", sym("sym")));
+        let list = list!(1, 2, list!(3, "str", intern("sym")));
         assert_eq!(format!("{}", list), "(1 2 (3 \"str\" sym))");
     }
 

--- a/src/list.rs
+++ b/src/list.rs
@@ -101,7 +101,7 @@ where
 mod tests {
     use super::*;
     use crate::expr::intern;
-    use crate::expr::shortcuts::num;
+    use crate::expr::test_utils::num;
     use crate::macros::list;
 
     #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,4 +1,4 @@
-use crate::expr::Expr;
+use crate::expr::{intern, Expr};
 use crate::list::{cons, List};
 use crate::macros::list;
 use crate::token::Token;
@@ -84,7 +84,7 @@ impl Parser {
                 if let Some(context) = self.contexts.last_mut() {
                     if let Some(quote_name) = get_quote_name(context.token.as_ref()) {
                         self.contexts.pop();
-                        expr = list!(Expr::Sym(quote_name.into()), expr).into();
+                        expr = list!(intern(quote_name), expr).into();
                         continue;
                     }
                     if context.car.is_none() {
@@ -148,7 +148,6 @@ fn get_quote_name(token: Option<&Token>) -> Option<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::expr::shortcuts::sym;
 
     #[test]
     fn test_parser() {
@@ -162,7 +161,7 @@ mod tests {
         ]);
 
         let parsed_expr = parser.parse().unwrap();
-        let expected_expr = list!(sym("add"), 1, 2).into();
+        let expected_expr = list!(intern("add"), 1, 2).into();
         assert_eq!(parsed_expr, expected_expr);
     }
 
@@ -172,7 +171,7 @@ mod tests {
         let mut parser = Parser::with_tokens(vec![Token::Quote, Token::Num(1_f64)]);
 
         let parsed_expr = parser.parse().unwrap();
-        let expected_expr = list!(sym("quote"), 1).into();
+        let expected_expr = list!(intern("quote"), 1).into();
         assert_eq!(parsed_expr, expected_expr);
     }
 
@@ -193,7 +192,7 @@ mod tests {
 
         let parsed_expr = parser.parse().unwrap();
         print!("{}", parsed_expr);
-        let expected_expr = list!(sym("quote"), list!(list!(1), 2)).into();
+        let expected_expr = list!(intern("quote"), list!(list!(1), 2)).into();
         assert_eq!(parsed_expr, expected_expr);
     }
 
@@ -205,21 +204,21 @@ mod tests {
         parser.add_tokens([Token::Quasiquote, Token::Num(1_f64)]);
 
         let parsed_expr = parser.parse().unwrap();
-        let expected_expr = list!(sym("quasiquote"), 1).into();
+        let expected_expr = list!(intern("quasiquote"), 1).into();
         assert_eq!(parsed_expr, expected_expr);
 
         // ,1
         parser.add_tokens([Token::Unquote, Token::Num(1_f64)]);
 
         let parsed_expr = parser.parse().unwrap();
-        let expected_expr = list!(sym("unquote"), 1).into();
+        let expected_expr = list!(intern("unquote"), 1).into();
         assert_eq!(parsed_expr, expected_expr);
 
         // ,@1
         parser.add_tokens([Token::UnquoteSplicing, Token::Num(1_f64)]);
 
         let parsed_expr = parser.parse().unwrap();
-        let expected_expr = list!(sym("unquote-splicing"), 1).into();
+        let expected_expr = list!(intern("unquote-splicing"), 1).into();
         assert_eq!(parsed_expr, expected_expr);
     }
 }


### PR DESCRIPTION
Implement `intern()`.

It doesn't really intern (i.e., convert a string into a integer) in a traditional sense, but it makes code more readable.