### PR TITLE
Tail-call optimisation prerequisite: Rc<Env> → EvalContext

### DIFF
--- a/src/bin/rusp/prelude/mod.rs
+++ b/src/bin/rusp/prelude/mod.rs
@@ -140,7 +140,7 @@ pub trait PreludeLoader {
 impl PreludeLoader for Evaluator {
     fn with_prelude() -> Self {
         let evaulator = Self::with_builtin();
-        let context = evaulator.root_context();
+        let context = evaulator.context();
 
         context.env.define_native_proc("print", native::print);
         context.env.define_native_proc("read", native::read);
@@ -149,13 +149,13 @@ impl PreludeLoader for Evaluator {
             .define_native_proc("parse-num", native::parse_num);
 
         for exprs in PRELUDE_SYMBOLS {
-            eval_prelude_str(exprs, &context);
+            eval_prelude_str(exprs, context);
         }
         for exprs in PRELUDE_MACROS {
-            eval_prelude_str(exprs, &context);
+            eval_prelude_str(exprs, context);
         }
         for exprs in PRELUDE_FUNCS {
-            eval_prelude_str(exprs, &context);
+            eval_prelude_str(exprs, context);
         }
 
         evaulator
@@ -170,7 +170,7 @@ fn eval_prelude_str(text: &str, context: &EvalContext) {
     loop {
         match parser.parse() {
             Ok(expr) => {
-                let _ = eval(&expr, &context)
+                let _ = eval(&expr, context)
                     .expect(format!("Failed to evaluate prelude: {text}").as_str());
             }
             Err(ParseError::NeedMoreToken) => {
@@ -193,7 +193,7 @@ mod tests {
 
     fn eval_str(text: &str) -> String {
         let evaluator = Evaluator::with_prelude();
-        eval_str_env(text, &evaluator.root_context())
+        eval_str_env(text, &evaluator.context())
     }
 
     fn eval_str_env(text: &str, context: &EvalContext) -> String {
@@ -248,10 +248,10 @@ mod tests {
     #[test]
     fn test_let() {
         let evaluator = Evaluator::with_prelude();
-        let context = evaluator.root_context();
+        let context = evaluator.context();
 
         assert_eq!(context.env.lookup("x"), None);
-        assert_eq!(eval_str_env("(let ((x 2)) (+ x 3))", &context), "5");
+        assert_eq!(eval_str_env("(let ((x 2)) (+ x 3))", context), "5");
         assert_eq!(context.env.lookup("x"), None);
     }
 

--- a/src/bin/rusp/prelude/native.rs
+++ b/src/bin/rusp/prelude/native.rs
@@ -1,16 +1,15 @@
-use std::{io::Write, rc::Rc};
+use std::io::Write;
 
 use rusp::{
     builtin::utils::{eval_to_str, get_exact_1_arg},
-    env::Env,
-    eval::{eval, EvalResult},
+    eval::{eval, EvalContext, EvalResult},
     expr::{Expr, NIL},
     list::List,
 };
 
-pub fn print(_: &str, args: &List, env: &Rc<Env>) -> EvalResult {
+pub fn print(_: &str, args: &List, context: &EvalContext) -> EvalResult {
     for expr in args.iter() {
-        match eval(expr, env)? {
+        match eval(expr, context)? {
             Expr::Str(text, _) => print!("{}", text), // w/o double quotes
             expr => print!("{}", expr),
         }
@@ -19,7 +18,7 @@ pub fn print(_: &str, args: &List, env: &Rc<Env>) -> EvalResult {
     Ok(NIL)
 }
 
-pub fn read(_: &str, _: &List, _: &Rc<Env>) -> EvalResult {
+pub fn read(_: &str, _: &List, _: &EvalContext) -> EvalResult {
     let mut input = String::new();
     if let Err(error) = std::io::stdin().read_line(&mut input) {
         return Err(format!("Error reading input: {}", error));
@@ -27,9 +26,9 @@ pub fn read(_: &str, _: &List, _: &Rc<Env>) -> EvalResult {
     Ok(Expr::from(input.trim()))
 }
 
-pub fn parse_num(proc_name: &str, args: &List, env: &Rc<Env>) -> EvalResult {
+pub fn parse_num(proc_name: &str, args: &List, context: &EvalContext) -> EvalResult {
     let expr = get_exact_1_arg(proc_name, args)?;
-    let text = eval_to_str(proc_name, expr, env)?;
+    let text = eval_to_str(proc_name, expr, context)?;
 
     match text.parse::<f64>() {
         Ok(num) => Ok(Expr::from(num)),
@@ -45,7 +44,7 @@ mod tests {
     #[test]
     fn test_parse_num() {
         let evaluator = Evaluator::with_builtin();
-        let parse_num = |args| parse_num("parse-num", &args, evaluator.root_env());
+        let parse_num = |args| parse_num("parse-num", &args, &evaluator.root_context());
 
         assert_eq!(parse_num(list!("1")), Ok(Expr::from(1)));
         assert_eq!(parse_num(list!("-24.5")), Ok(Expr::from(-24.5)));

--- a/src/bin/rusp/prelude/native.rs
+++ b/src/bin/rusp/prelude/native.rs
@@ -44,7 +44,7 @@ mod tests {
     #[test]
     fn test_parse_num() {
         let evaluator = Evaluator::with_builtin();
-        let parse_num = |args| parse_num("parse-num", &args, &evaluator.root_context());
+        let parse_num = |args| parse_num("parse-num", &args, &evaluator.context());
 
         assert_eq!(parse_num(list!("1")), Ok(Expr::from(1)));
         assert_eq!(parse_num(list!("-24.5")), Ok(Expr::from(-24.5)));

--- a/src/builtin/num.rs
+++ b/src/builtin/num.rs
@@ -89,84 +89,84 @@ mod tests {
     #[test]
     fn test_add() {
         let evaluator = Evaluator::new();
-        let context = evaluator.root_context();
+        let context = evaluator.context();
 
         // (+ 1) => 1
         let args = list!(1);
-        assert_eq!(add("", &args, &context), Ok(num(1)));
+        assert_eq!(add("", &args, context), Ok(num(1)));
 
         // (+ 2 1) => 3
         let args = list!(2, 1);
-        assert_eq!(add("", &args, &context), Ok(num(3)));
+        assert_eq!(add("", &args, context), Ok(num(3)));
     }
 
     #[test]
     fn test_minus() {
         let evaluator = Evaluator::new();
-        let context = evaluator.root_context();
+        let context = evaluator.context();
 
         // (- 1) => -1
         let args = list!(1);
-        assert_eq!(subtract("", &args, &context), Ok(num(-1)));
+        assert_eq!(subtract("", &args, context), Ok(num(-1)));
 
         // (- 2 1) => 1
         let args = list!(2, 1);
-        assert_eq!(subtract("", &args, &context), Ok(num(1)));
+        assert_eq!(subtract("", &args, context), Ok(num(1)));
     }
 
     #[test]
     fn test_multiply() {
         let evaluator = Evaluator::new();
-        let context = evaluator.root_context();
+        let context = evaluator.context();
 
         // (* 1) => 1
         let args = list!(1);
-        assert_eq!(multiply("", &args, &context), Ok(num(1)));
+        assert_eq!(multiply("", &args, context), Ok(num(1)));
 
         // (* 2 1) => 2
         let args = list!(2, 1);
-        assert_eq!(multiply("", &args, &context), Ok(num(2)));
+        assert_eq!(multiply("", &args, context), Ok(num(2)));
 
         // (* 3 2 1) => 6
         let args = list!(3, 2, 1);
-        assert_eq!(multiply("", &args, &context), Ok(num(6)));
+        assert_eq!(multiply("", &args, context), Ok(num(6)));
     }
 
     #[test]
     fn test_divide() {
         let evaluator = Evaluator::new();
-        let context = evaluator.root_context();
+        let context = evaluator.context();
 
         // (/ 2) => 0.5
         let args = list!(2);
-        assert_eq!(divide("", &args, &context), Ok(num(0.5)));
+        assert_eq!(divide("", &args, context), Ok(num(0.5)));
 
         // (/ 4 2) => 2
         let args = list!(4, 2);
-        assert_eq!(divide("", &args, &context), Ok(num(2)));
+        assert_eq!(divide("", &args, context), Ok(num(2)));
     }
 
     #[test]
     fn test_modulo() {
         let evaluator = Evaluator::new();
-        let context = evaluator.root_context();
+        let context = evaluator.context();
 
         // (% 1 2) => 1
-        assert_eq!(modulo("", &list!(1, 2), &context), Ok(Expr::from(1)));
+        assert_eq!(modulo("", &list!(1, 2), context), Ok(Expr::from(1)));
 
         // (% 11 3) => 2
-        assert_eq!(modulo("", &list!(11, 3), &context), Ok(num(2)));
+        assert_eq!(modulo("", &list!(11, 3), context), Ok(num(2)));
 
         // (% 11 4) => 3
-        assert_eq!(modulo("", &list!(11, 4), &context), Ok(num(3)));
+        assert_eq!(modulo("", &list!(11, 4), context), Ok(num(3)));
 
         // (% 1) => error
-        assert!(modulo("", &list!(1), &context).is_err());
+        assert!(modulo("", &list!(1), context).is_err());
 
         // (% 1 1 1) => error
-        assert!(modulo("", &list!(1, 1, 1), &context).is_err());
+        assert!(modulo("", &list!(1, 1, 1), context).is_err());
 
         // (% "1" "2") => error
-        assert!(modulo("", &list!("1", "2"), &context).is_err());
+        assert!(modulo("", &list!("1", "2"), context).is_err());
     }
 }

--- a/src/builtin/num.rs
+++ b/src/builtin/num.rs
@@ -1,14 +1,11 @@
-use std::rc::Rc;
-
-use crate::env::Env;
-use crate::eval::{eval, EvalResult};
+use crate::eval::{eval, EvalContext, EvalResult};
 use crate::expr::Expr;
 use crate::list::List;
 
 use super::utils::{eval_to_num, get_exact_1_arg, get_exact_2_args};
 
-pub fn is_num(proc_name: &str, args: &List, env: &Rc<Env>) -> EvalResult {
-    if let Expr::Num(_, _) = eval(get_exact_1_arg(proc_name, args)?, env)? {
+pub fn is_num(proc_name: &str, args: &List, context: &EvalContext) -> EvalResult {
+    if let Expr::Num(_, _) = eval(get_exact_1_arg(proc_name, args)?, context)? {
         Ok(true.into())
     } else {
         Ok(false.into())
@@ -18,7 +15,7 @@ pub fn is_num(proc_name: &str, args: &List, env: &Rc<Env>) -> EvalResult {
 fn binary_operation(
     proc_name: &str,
     args: &List,
-    env: &Rc<Env>,
+    context: &EvalContext,
     identity: f64,
     is_associative: bool,
     func: fn(lhs: f64, rhs: f64) -> f64,
@@ -26,7 +23,7 @@ fn binary_operation(
     let mut result = identity;
 
     for (index, arg) in args.iter().enumerate() {
-        let value = eval_to_num(proc_name, arg, env)?;
+        let value = eval_to_num(proc_name, arg, context)?;
         if index == 0 && args.len() > 1 && !is_associative {
             result = value;
         } else {
@@ -37,26 +34,26 @@ fn binary_operation(
     Ok(Expr::Num(result, None))
 }
 
-pub fn add(proc_name: &str, args: &List, env: &Rc<Env>) -> EvalResult {
-    binary_operation(proc_name, args, env, 0_f64, true, |lhs, rhs| lhs + rhs)
+pub fn add(proc_name: &str, args: &List, context: &EvalContext) -> EvalResult {
+    binary_operation(proc_name, args, context, 0_f64, true, |lhs, rhs| lhs + rhs)
 }
 
-pub fn subtract(proc_name: &str, args: &List, env: &Rc<Env>) -> EvalResult {
-    binary_operation(proc_name, args, env, 0_f64, false, |lhs, rhs| lhs - rhs)
+pub fn subtract(proc_name: &str, args: &List, context: &EvalContext) -> EvalResult {
+    binary_operation(proc_name, args, context, 0_f64, false, |lhs, rhs| lhs - rhs)
 }
 
-pub fn multiply(proc_name: &str, args: &List, env: &Rc<Env>) -> EvalResult {
-    binary_operation(proc_name, args, env, 1_f64, true, |lhs, rhs| lhs * rhs)
+pub fn multiply(proc_name: &str, args: &List, context: &EvalContext) -> EvalResult {
+    binary_operation(proc_name, args, context, 1_f64, true, |lhs, rhs| lhs * rhs)
 }
 
-pub fn divide(proc_name: &str, args: &List, env: &Rc<Env>) -> EvalResult {
-    binary_operation(proc_name, args, env, 1_f64, false, |lhs, rhs| lhs / rhs)
+pub fn divide(proc_name: &str, args: &List, context: &EvalContext) -> EvalResult {
+    binary_operation(proc_name, args, context, 1_f64, false, |lhs, rhs| lhs / rhs)
 }
 
-pub fn modulo(proc_name: &str, args: &List, env: &Rc<Env>) -> EvalResult {
+pub fn modulo(proc_name: &str, args: &List, context: &EvalContext) -> EvalResult {
     let (lhs, rhs) = get_exact_2_args(proc_name, args)?;
-    let lhs = eval_to_num(proc_name, lhs, env)?;
-    let rhs = eval_to_num(proc_name, rhs, env)?;
+    let lhs = eval_to_num(proc_name, lhs, context)?;
+    let rhs = eval_to_num(proc_name, rhs, context)?;
 
     Ok(Expr::Num(lhs % rhs, None))
 }
@@ -64,22 +61,22 @@ pub fn modulo(proc_name: &str, args: &List, env: &Rc<Env>) -> EvalResult {
 fn logical_operation(
     proc_name: &str,
     args: &List,
-    env: &Rc<Env>,
+    context: &EvalContext,
     func: fn(lhs: f64, rhs: f64) -> bool,
 ) -> EvalResult {
     let (lhs, rhs) = get_exact_2_args(proc_name, args)?;
     Ok(Expr::from(func(
-        eval_to_num(proc_name, lhs, env)?,
-        eval_to_num(proc_name, rhs, env)?,
+        eval_to_num(proc_name, lhs, context)?,
+        eval_to_num(proc_name, rhs, context)?,
     )))
 }
 
-pub fn less(proc_name: &str, args: &List, env: &Rc<Env>) -> EvalResult {
-    logical_operation(proc_name, args, env, |lhs, rhs| lhs < rhs)
+pub fn less(proc_name: &str, args: &List, context: &EvalContext) -> EvalResult {
+    logical_operation(proc_name, args, context, |lhs, rhs| lhs < rhs)
 }
 
-pub fn greater(proc_name: &str, args: &List, env: &Rc<Env>) -> EvalResult {
-    logical_operation(proc_name, args, env, |lhs, rhs| lhs > rhs)
+pub fn greater(proc_name: &str, args: &List, context: &EvalContext) -> EvalResult {
+    logical_operation(proc_name, args, context, |lhs, rhs| lhs > rhs)
 }
 
 #[cfg(test)]
@@ -92,84 +89,84 @@ mod tests {
     #[test]
     fn test_add() {
         let evaluator = Evaluator::new();
-        let env = evaluator.root_env();
+        let context = evaluator.root_context();
 
         // (+ 1) => 1
         let args = list!(1);
-        assert_eq!(add("", &args, &env), Ok(num(1)));
+        assert_eq!(add("", &args, &context), Ok(num(1)));
 
         // (+ 2 1) => 3
         let args = list!(2, 1);
-        assert_eq!(add("", &args, &env), Ok(num(3)));
+        assert_eq!(add("", &args, &context), Ok(num(3)));
     }
 
     #[test]
     fn test_minus() {
         let evaluator = Evaluator::new();
-        let env = evaluator.root_env();
+        let context = evaluator.root_context();
 
         // (- 1) => -1
         let args = list!(1);
-        assert_eq!(subtract("", &args, &env), Ok(num(-1)));
+        assert_eq!(subtract("", &args, &context), Ok(num(-1)));
 
         // (- 2 1) => 1
         let args = list!(2, 1);
-        assert_eq!(subtract("", &args, &env), Ok(num(1)));
+        assert_eq!(subtract("", &args, &context), Ok(num(1)));
     }
 
     #[test]
     fn test_multiply() {
         let evaluator = Evaluator::new();
-        let env = evaluator.root_env();
+        let context = evaluator.root_context();
 
         // (* 1) => 1
         let args = list!(1);
-        assert_eq!(multiply("", &args, &env), Ok(num(1)));
+        assert_eq!(multiply("", &args, &context), Ok(num(1)));
 
         // (* 2 1) => 2
         let args = list!(2, 1);
-        assert_eq!(multiply("", &args, &env), Ok(num(2)));
+        assert_eq!(multiply("", &args, &context), Ok(num(2)));
 
         // (* 3 2 1) => 6
         let args = list!(3, 2, 1);
-        assert_eq!(multiply("", &args, &env), Ok(num(6)));
+        assert_eq!(multiply("", &args, &context), Ok(num(6)));
     }
 
     #[test]
     fn test_divide() {
         let evaluator = Evaluator::new();
-        let env = evaluator.root_env();
+        let context = evaluator.root_context();
 
         // (/ 2) => 0.5
         let args = list!(2);
-        assert_eq!(divide("", &args, &env), Ok(num(0.5)));
+        assert_eq!(divide("", &args, &context), Ok(num(0.5)));
 
         // (/ 4 2) => 2
         let args = list!(4, 2);
-        assert_eq!(divide("", &args, &env), Ok(num(2)));
+        assert_eq!(divide("", &args, &context), Ok(num(2)));
     }
 
     #[test]
     fn test_modulo() {
         let evaluator = Evaluator::new();
-        let env = evaluator.root_env();
+        let context = evaluator.root_context();
 
         // (% 1 2) => 1
-        assert_eq!(modulo("", &list!(1, 2), &env), Ok(Expr::from(1)));
+        assert_eq!(modulo("", &list!(1, 2), &context), Ok(Expr::from(1)));
 
         // (% 11 3) => 2
-        assert_eq!(modulo("", &list!(11, 3), &env), Ok(num(2)));
+        assert_eq!(modulo("", &list!(11, 3), &context), Ok(num(2)));
 
         // (% 11 4) => 3
-        assert_eq!(modulo("", &list!(11, 4), &env), Ok(num(3)));
+        assert_eq!(modulo("", &list!(11, 4), &context), Ok(num(3)));
 
         // (% 1) => error
-        assert!(modulo("", &list!(1), &env).is_err());
+        assert!(modulo("", &list!(1), &context).is_err());
 
         // (% 1 1 1) => error
-        assert!(modulo("", &list!(1, 1, 1), &env).is_err());
+        assert!(modulo("", &list!(1, 1, 1), &context).is_err());
 
         // (% "1" "2") => error
-        assert!(modulo("", &list!("1", "2"), &env).is_err());
+        assert!(modulo("", &list!("1", "2"), &context).is_err());
     }
 }

--- a/src/builtin/primitive.rs
+++ b/src/builtin/primitive.rs
@@ -1,8 +1,5 @@
-use std::rc::Rc;
-
 use crate::{
-    env::Env,
-    eval::{eval, EvalResult},
+    eval::{eval, EvalContext, EvalResult},
     expr::{Expr, NIL},
     list::List,
     proc::Proc,
@@ -10,44 +7,44 @@ use crate::{
 
 use super::utils::{get_exact_1_arg, get_exact_2_args, make_formal_args, make_syntax_error};
 
-pub fn atom(proc_name: &str, args: &List, env: &Rc<Env>) -> EvalResult {
+pub fn atom(proc_name: &str, args: &List, context: &EvalContext) -> EvalResult {
     let expr = get_exact_1_arg(proc_name, args)?;
 
-    Ok(eval(expr, env)?.is_atom().into())
+    Ok(eval(expr, context)?.is_atom().into())
 }
 
-pub fn car(proc_name: &str, args: &List, env: &Rc<Env>) -> EvalResult {
+pub fn car(proc_name: &str, args: &List, context: &EvalContext) -> EvalResult {
     let expr = get_exact_1_arg(proc_name, args)?;
 
-    if let Expr::List(List::Cons(cons), _) = eval(expr, env)? {
+    if let Expr::List(List::Cons(cons), _) = eval(expr, context)? {
         Ok(cons.car.as_ref().clone())
     } else {
         Err(make_syntax_error(proc_name, args))
     }
 }
 
-pub fn cdr(proc_name: &str, args: &List, env: &Rc<Env>) -> EvalResult {
+pub fn cdr(proc_name: &str, args: &List, context: &EvalContext) -> EvalResult {
     let expr = get_exact_1_arg(proc_name, args)?;
 
-    if let Expr::List(List::Cons(cons), _) = eval(expr, env)? {
+    if let Expr::List(List::Cons(cons), _) = eval(expr, context)? {
         Ok(cons.cdr.as_ref().clone().into())
     } else {
         Err(make_syntax_error(proc_name, args))
     }
 }
 
-pub fn cons(proc_name: &str, args: &List, env: &Rc<Env>) -> EvalResult {
+pub fn cons(proc_name: &str, args: &List, context: &EvalContext) -> EvalResult {
     let (car, cdr) = get_exact_2_args(proc_name, args)?;
 
-    let car = eval(car, env)?;
-    let Expr::List(cdr, _) = eval(cdr, env)? else {
+    let car = eval(car, context)?;
+    let Expr::List(cdr, _) = eval(cdr, context)? else {
         return Err(format!("{proc_name}: {cdr} does not evaluate to a list."));
     };
 
     Ok(crate::list::cons(car, cdr).into())
 }
 
-pub fn cond(proc_name: &str, args: &List, env: &Rc<Env>) -> EvalResult {
+pub fn cond(proc_name: &str, args: &List, context: &EvalContext) -> EvalResult {
     let mut iter = args.iter();
     loop {
         match iter.next() {
@@ -56,9 +53,9 @@ pub fn cond(proc_name: &str, args: &List, env: &Rc<Env>) -> EvalResult {
             }
             Some(Expr::List(List::Cons(cons), _)) => {
                 let car = &cons.car;
-                if eval(car, env)?.is_truthy() {
+                if eval(car, context)?.is_truthy() {
                     if let Some(expr) = cons.cdar() {
-                        return eval(expr, env);
+                        return eval(expr, context);
                     } else {
                         break;
                     }
@@ -71,12 +68,12 @@ pub fn cond(proc_name: &str, args: &List, env: &Rc<Env>) -> EvalResult {
     Err(make_syntax_error(proc_name, args))
 }
 
-pub fn define(proc_name: &str, args: &List, env: &Rc<Env>) -> EvalResult {
+pub fn define(proc_name: &str, args: &List, context: &EvalContext) -> EvalResult {
     let mut iter = args.iter();
     match iter.next() {
         Some(Expr::Sym(name, _)) => {
             if let Some(expr) = iter.next() {
-                env.define(name, eval(expr, env)?);
+                context.env.define(name, eval(expr, context)?);
                 Ok(NIL)
             } else {
                 Err(format!(
@@ -89,14 +86,14 @@ pub fn define(proc_name: &str, args: &List, env: &Rc<Env>) -> EvalResult {
                 return Err(format!("{proc_name}: expects a list of symbols"));
             };
 
-            env.define(
+            context.env.define(
                 name,
                 Expr::Proc(
                     Proc::Closure {
                         name: Some(name.to_string()),
                         formal_args: make_formal_args(&cons.cdr)?,
                         body: Box::new(iter.into()),
-                        outer_env: env.clone(),
+                        outer_context: context.clone(),
                     },
                     None,
                 ),
@@ -107,7 +104,7 @@ pub fn define(proc_name: &str, args: &List, env: &Rc<Env>) -> EvalResult {
     }
 }
 
-pub fn defmacro(proc_name: &str, args: &List, env: &Rc<Env>) -> EvalResult {
+pub fn defmacro(proc_name: &str, args: &List, context: &EvalContext) -> EvalResult {
     let mut iter = args.iter();
 
     let (macro_name, formal_args) = match iter.next() {
@@ -130,7 +127,7 @@ pub fn defmacro(proc_name: &str, args: &List, env: &Rc<Env>) -> EvalResult {
         _ => return Err(make_syntax_error(proc_name, args)),
     };
 
-    env.define(
+    context.env.define(
         macro_name,
         Expr::Proc(
             Proc::Macro {
@@ -145,19 +142,19 @@ pub fn defmacro(proc_name: &str, args: &List, env: &Rc<Env>) -> EvalResult {
     Ok(NIL)
 }
 
-pub fn eq(proc_name: &str, args: &List, env: &Rc<Env>) -> EvalResult {
+pub fn eq(proc_name: &str, args: &List, context: &EvalContext) -> EvalResult {
     let (left, right) = get_exact_2_args(proc_name, args)?;
 
-    Ok((eval(left, env)? == eval(right, env)?).into())
+    Ok((eval(left, context)? == eval(right, context)?).into())
 }
 
-pub fn eval_(proc_name: &str, args: &List, env: &Rc<Env>) -> EvalResult {
+pub fn eval_(proc_name: &str, args: &List, context: &EvalContext) -> EvalResult {
     let expr = get_exact_1_arg(proc_name, args)?;
 
-    eval(&eval(expr, env)?, env)
+    eval(&eval(expr, context)?, context)
 }
 
-pub fn lambda(proc_name: &str, args: &List, env: &Rc<Env>) -> EvalResult {
+pub fn lambda(proc_name: &str, args: &List, context: &EvalContext) -> EvalResult {
     let mut iter = args.iter();
 
     let Some(Expr::List(list, _)) = iter.next() else {
@@ -169,20 +166,20 @@ pub fn lambda(proc_name: &str, args: &List, env: &Rc<Env>) -> EvalResult {
             name: None,
             formal_args: make_formal_args(list)?,
             body: Box::new(iter.into()),
-            outer_env: env.clone(),
+            outer_context: context.clone(),
         },
         None, // TODO: add span
     ))
 }
 
-pub fn set(proc_name: &str, args: &List, env: &Rc<Env>) -> EvalResult {
+pub fn set(proc_name: &str, args: &List, context: &EvalContext) -> EvalResult {
     let (name_expr, value_expr) = get_exact_2_args(proc_name, args)?;
 
     let Expr::Sym(name, _) = name_expr else {
         return Err("".to_owned());
     };
 
-    env.update(name, eval(value_expr, &env)?);
+    context.env.update(name, eval(value_expr, context)?);
 
     Ok(NIL)
 }
@@ -197,26 +194,26 @@ mod tests {
     #[test]
     fn test_define() {
         let evaluator = Evaluator::new();
-        let env = evaluator.root_env();
+        let context = evaluator.root_context();
 
         // (define name "value")
-        let ret = define("", &list!(intern("name"), "value"), &env);
+        let ret = define("", &list!(intern("name"), "value"), &context);
         assert_eq!(ret, Ok(NIL));
-        assert_eq!(env.lookup("name"), Some("value".into()));
+        assert_eq!(context.env.lookup("name"), Some("value".into()));
     }
 
     #[test]
     fn test_eq() {
         let evaluator = Evaluator::new();
-        let env = evaluator.root_env();
+        let context = evaluator.root_context();
 
         // (eq 1 1) => #t
-        assert_ne!(eq("", &list!(1, 1), &env).unwrap(), NIL);
+        assert_ne!(eq("", &list!(1, 1), &context).unwrap(), NIL);
         // (eq 1 2) => ()
-        assert_eq!(eq("", &list!(1, 2), &env).unwrap(), NIL);
+        assert_eq!(eq("", &list!(1, 2), &context).unwrap(), NIL);
         // (eq "str" "str") => #t
-        assert_ne!(eq("", &list!("str", "str"), &env).unwrap(), NIL);
+        assert_ne!(eq("", &list!("str", "str"), &context).unwrap(), NIL);
         // (eq 1 "1") => ()
-        assert_eq!(eq("", &list!(1, "1"), &env).unwrap(), NIL);
+        assert_eq!(eq("", &list!(1, "1"), &context).unwrap(), NIL);
     }
 }

--- a/src/builtin/primitive.rs
+++ b/src/builtin/primitive.rs
@@ -194,10 +194,10 @@ mod tests {
     #[test]
     fn test_define() {
         let evaluator = Evaluator::new();
-        let context = evaluator.root_context();
+        let context = evaluator.context();
 
         // (define name "value")
-        let ret = define("", &list!(intern("name"), "value"), &context);
+        let ret = define("", &list!(intern("name"), "value"), context);
         assert_eq!(ret, Ok(NIL));
         assert_eq!(context.env.lookup("name"), Some("value".into()));
     }
@@ -205,15 +205,15 @@ mod tests {
     #[test]
     fn test_eq() {
         let evaluator = Evaluator::new();
-        let context = evaluator.root_context();
+        let context = evaluator.context();
 
         // (eq 1 1) => #t
-        assert_ne!(eq("", &list!(1, 1), &context).unwrap(), NIL);
+        assert_ne!(eq("", &list!(1, 1), context).unwrap(), NIL);
         // (eq 1 2) => ()
-        assert_eq!(eq("", &list!(1, 2), &context).unwrap(), NIL);
+        assert_eq!(eq("", &list!(1, 2), context).unwrap(), NIL);
         // (eq "str" "str") => #t
-        assert_ne!(eq("", &list!("str", "str"), &context).unwrap(), NIL);
+        assert_ne!(eq("", &list!("str", "str"), context).unwrap(), NIL);
         // (eq 1 "1") => ()
-        assert_eq!(eq("", &list!(1, "1"), &context).unwrap(), NIL);
+        assert_eq!(eq("", &list!(1, "1"), context).unwrap(), NIL);
     }
 }

--- a/src/builtin/quote.rs
+++ b/src/builtin/quote.rs
@@ -90,16 +90,16 @@ mod tests {
     #[test]
     fn test_quote() {
         let evaluator = Evaluator::new();
-        let context = evaluator.root_context();
+        let context = evaluator.context();
         // (quote (1 2)) => (1 2)
-        let result = quote("", &list!(list!(1, 2)), &context);
+        let result = quote("", &list!(list!(1, 2)), context);
         assert_eq!(result, Ok(list!(1, 2).into()));
     }
 
     #[test]
     fn test_quasiquote() {
         let evaluator = Evaluator::new();
-        let context = evaluator.root_context();
+        let context = evaluator.context();
 
         context.env.define("x", 2);
 
@@ -107,7 +107,7 @@ mod tests {
         let result = quasiquote(
             "",
             &list!(list!(0, 1, list!(intern("unquote"), intern("x")), 3)),
-            &context,
+            context,
         );
         assert_eq!(result, Ok(list!(0, 1, 2, 3).into()));
     }
@@ -115,7 +115,7 @@ mod tests {
     #[test]
     fn test_quasiquote_unquote() {
         let evaluator = Evaluator::with_builtin(); // make `num-add` available
-        let context = evaluator.root_context();
+        let context = evaluator.context();
 
         // (quasiquote (0 (unquote (+ 1 2)) 4)) => (0 3 4)
         let result = quasiquote(
@@ -125,7 +125,7 @@ mod tests {
                 list!(intern("unquote"), list!(intern("num-add"), 1, 2)),
                 4
             )),
-            &context,
+            context,
         );
         assert_eq!(result, Ok(list!(0, 3, 4).into()));
     }
@@ -133,7 +133,7 @@ mod tests {
     #[test]
     fn test_quasiquote_unquote_splicing() {
         let evaluator = Evaluator::new();
-        let context = evaluator.root_context();
+        let context = evaluator.context();
 
         // (quasiquote (0 (unquote-splicing (quote (1 2 3))) 4)) => (0 1 2 3 4)
         let result = quasiquote(
@@ -146,7 +146,7 @@ mod tests {
                 ),
                 4
             )),
-            &context,
+            context,
         );
         assert_eq!(result, Ok(list!(0, 1, 2, 3, 4).into()));
     }

--- a/src/builtin/str.rs
+++ b/src/builtin/str.rs
@@ -111,114 +111,114 @@ mod tests {
     #[test]
     fn test_is_str() {
         let evaluator = Evaluator::new();
-        let context = evaluator.root_context();
+        let context = evaluator.context();
 
         // (str? "abc") => 1
-        assert_eq!(is_str("", &list!("abc"), &context), Ok(Expr::from(true)));
+        assert_eq!(is_str("", &list!("abc"), context), Ok(Expr::from(true)));
 
         // (str? 1) => '()
-        assert_eq!(is_str("", &list!(1), &context), Ok(Expr::from(false)));
+        assert_eq!(is_str("", &list!(1), context), Ok(Expr::from(false)));
 
         // (str? "abc" "def") => error
-        assert!(is_str("", &list!("abc", "def"), &context).is_err());
+        assert!(is_str("", &list!("abc", "def"), context).is_err());
     }
 
     #[test]
     fn test_compare() {
         let evaluator = Evaluator::new();
-        let context = evaluator.root_context();
+        let context = evaluator.context();
 
         // (str-compare "abc" "def") => 1
         assert_eq!(
-            compare("", &list!("abc", "def"), &context),
+            compare("", &list!("abc", "def"), context),
             Ok(Expr::from(-1))
         );
 
         // (str-compare "abc" "abc") => 1
         assert_eq!(
-            compare("", &list!("def", "def"), &context),
+            compare("", &list!("def", "def"), context),
             Ok(Expr::from(0))
         );
 
         // (str-compare "def" "abc") => 1
         assert_eq!(
-            compare("", &list!("def", "abc"), &context),
+            compare("", &list!("def", "abc"), context),
             Ok(Expr::from(1))
         );
 
         // (str? "abc") => error
-        assert!(compare("", &list!("abc"), &context).is_err());
+        assert!(compare("", &list!("abc"), context).is_err());
 
         // (str? "abc" "abc" "abc") => error
-        assert!(compare("", &list!("abc", "abc", "abc"), &context).is_err());
+        assert!(compare("", &list!("abc", "abc", "abc"), context).is_err());
     }
 
     #[test]
     fn test_concat() {
         let evaluator = Evaluator::new();
-        let context = evaluator.root_context();
+        let context = evaluator.context();
 
         // (str-concat "abc" "def") => "abcdef"
         assert_eq!(
-            concat("", &list!("abc", "def"), &context),
+            concat("", &list!("abc", "def"), context),
             Ok(Expr::from("abcdef"))
         );
 
         // (str-concat "abc" "-" "def" "-" "123") => "abc-def-123"
         assert_eq!(
-            concat("", &list!("abc", "-", "def", "-", "123"), &context),
+            concat("", &list!("abc", "-", "def", "-", "123"), context),
             Ok(Expr::from("abc-def-123"))
         );
 
         // edge case: (str-conca) => ""
-        assert_eq!(concat("", &list!(), &context), Ok(Expr::from("")));
+        assert_eq!(concat("", &list!(), context), Ok(Expr::from("")));
 
         // edge case: (str-concat "abc") => "abc"
-        assert_eq!(concat("", &list!("abc"), &context), Ok(Expr::from("abc")));
+        assert_eq!(concat("", &list!("abc"), context), Ok(Expr::from("abc")));
     }
 
     #[test]
     fn test_slice() {
         let evaluator = Evaluator::new();
-        let context = evaluator.root_context();
+        let context = evaluator.context();
 
         // (str-slice "abcdef" 0 1) => "a"
         assert_eq!(
-            slice("", &list!("abcdef", 0, 1), &context),
+            slice("", &list!("abcdef", 0, 1), context),
             Ok(Expr::from("a"))
         );
 
         // (str-slice "abcdef" 0 2) => "ab"
         assert_eq!(
-            slice("", &list!("abcdef", 0, 2), &context),
+            slice("", &list!("abcdef", 0, 2), context),
             Ok(Expr::from("ab"))
         );
 
         // (str-slice "abcdef" 1 3) => "bc"
         assert_eq!(
-            slice("", &list!("abcdef", 1, 3), &context),
+            slice("", &list!("abcdef", 1, 3), context),
             Ok(Expr::from("bc"))
         );
 
         // (str-slice "abcdef" 1) => "abcdef"
         assert_eq!(
-            slice("", &list!("abcdef", 1), &context),
+            slice("", &list!("abcdef", 1), context),
             Ok(Expr::from("bcdef"))
         );
 
         // (str-slice "abcdef" -2) => ""
         assert_eq!(
-            slice("", &list!("abcdef", -2), &context),
+            slice("", &list!("abcdef", -2), context),
             Ok(Expr::from("ef"))
         );
 
         // (str-slice "abcdef" -2 -4) => ""
         assert_eq!(
-            slice("", &list!("abcdef", -2, -4), &context),
+            slice("", &list!("abcdef", -2, -4), context),
             Ok(Expr::from("cd"))
         );
 
         // error: (str-slice "abcdef" 0.5 1)
-        assert!(slice("", &list!("abcdef", 0.5, 1), &context).is_err());
+        assert!(slice("", &list!("abcdef", 0.5, 1), context).is_err());
     }
 }

--- a/src/builtin/utils.rs
+++ b/src/builtin/utils.rs
@@ -1,7 +1,4 @@
-use std::rc::Rc;
-
-use crate::env::Env;
-use crate::eval::{eval, EvalError};
+use crate::eval::{eval, EvalContext, EvalError};
 use crate::expr::{intern, Expr};
 use crate::list::{cons, List};
 
@@ -97,8 +94,12 @@ pub fn make_formal_args(list: &List) -> Result<Vec<String>, EvalError> {
     Ok(formal_args)
 }
 
-pub fn eval_to_str(proc_name: &str, expr: &Expr, env: &Rc<Env>) -> Result<String, EvalError> {
-    match eval(expr, env)? {
+pub fn eval_to_str(
+    proc_name: &str,
+    expr: &Expr,
+    context: &EvalContext,
+) -> Result<String, EvalError> {
+    match eval(expr, context)? {
         Expr::Str(text, _) => Ok(text),
         _ => Err(format!(
             "{proc_name}: {expr} does not evaluate to a string."
@@ -106,8 +107,8 @@ pub fn eval_to_str(proc_name: &str, expr: &Expr, env: &Rc<Env>) -> Result<String
     }
 }
 
-pub fn eval_to_num(proc_name: &str, expr: &Expr, env: &Rc<Env>) -> Result<f64, EvalError> {
-    match eval(expr, env)? {
+pub fn eval_to_num(proc_name: &str, expr: &Expr, context: &EvalContext) -> Result<f64, EvalError> {
+    match eval(expr, context)? {
         Expr::Num(value, _) => Ok(value),
         _ => Err(format!(
             "{proc_name}: {expr} does not evaluate to a number."

--- a/src/env.rs
+++ b/src/env.rs
@@ -23,7 +23,7 @@ impl Env {
         })
     }
 
-    pub fn derive_from(base: &Rc<Env>) -> Rc<Self> {
+    pub(crate) fn derive_from(base: &Rc<Env>) -> Rc<Self> {
         let derived_env = Rc::new(Self {
             base: Some(base.clone()),
             vars: RefCell::new(HashMap::new()),
@@ -103,8 +103,8 @@ impl Env {
         self.is_reachable.set(true);
 
         self.vars.borrow().values().for_each(|expr| {
-            if let Expr::Proc(Proc::Closure { outer_env, .. }, _) = expr {
-                outer_env.gc_mark();
+            if let Expr::Proc(Proc::Closure { outer_context, .. }, _) = expr {
+                outer_context.env.gc_mark();
             }
         });
     }

--- a/src/env.rs
+++ b/src/env.rs
@@ -121,12 +121,11 @@ impl Env {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{eval::Evaluator, expr::test_utils::num};
+    use crate::expr::test_utils::num;
 
     #[test]
     fn test_set() {
-        let evaluator = Evaluator::new();
-        let env = evaluator.root_env();
+        let env = Env::root(Weak::new());
         assert_eq!(env.vars.borrow().len(), 0);
         env.define("one", 1);
         assert_eq!(env.vars.borrow().get("one"), Some(&num(1)));
@@ -134,8 +133,7 @@ mod tests {
 
     #[test]
     fn test_update() {
-        let evaluator = Evaluator::new();
-        let env = evaluator.root_env();
+        let env = Env::root(Weak::new());
         assert_eq!(env.update("name", 1), false);
 
         env.define("name", 0);
@@ -144,8 +142,7 @@ mod tests {
 
     #[test]
     fn test_lookup() {
-        let evaluator = Evaluator::new();
-        let env = evaluator.root_env();
+        let env = Env::root(Weak::new());
         assert_eq!(env.lookup("one"), None);
         env.define("one", num(1));
         assert_eq!(env.lookup("one"), Some(num(1)));
@@ -153,8 +150,7 @@ mod tests {
 
     #[test]
     fn test_derive_update() {
-        let evaluator = Evaluator::new();
-        let base = evaluator.root_env();
+        let base = Env::root(Weak::new());
         let derived = Env::derive_from(&base);
 
         base.define("one", 1);
@@ -170,8 +166,7 @@ mod tests {
 
     #[test]
     fn test_derive_lookup() {
-        let evaluator = Evaluator::new();
-        let base = evaluator.root_env();
+        let base = Env::root(Weak::new());
         let derived = Env::derive_from(&base);
 
         assert_eq!(derived.lookup("two"), None);
@@ -185,8 +180,7 @@ mod tests {
 
     #[test]
     fn test_clone() {
-        let evaluator = Evaluator::new();
-        let original = evaluator.root_env();
+        let original = Env::root(Weak::new());
         let cloned = original.clone();
 
         original.define("one", 1);

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -31,8 +31,8 @@ pub fn eval(expr: &Expr, context: &EvalContext) -> EvalResult {
             None => Err(format!("Undefined symbol: {:?}", name)),
         },
         Expr::List(List::Cons(cons), _) => match cons.car.as_ref() {
-            Expr::Sym(text, _) if text == "quote" => quote(text, &cons.cdr, &context),
-            Expr::Sym(text, _) if text == "quasiquote" => quasiquote(text, &cons.cdr, &context),
+            Expr::Sym(text, _) if text == "quote" => quote(text, &cons.cdr, context),
+            Expr::Sym(text, _) if text == "quasiquote" => quasiquote(text, &cons.cdr, context),
             _ => {
                 if let Expr::Proc(proc, _) = eval(&cons.car, context)? {
                     let args = &cons.cdr;
@@ -74,14 +74,12 @@ impl Evaluator {
         return &self.context.env;
     }
 
-    pub fn root_context(&self) -> EvalContext {
-        EvalContext {
-            env: self.root_env().clone(),
-        }
+    pub fn context(&self) -> &EvalContext {
+        &self.context
     }
 
     pub fn eval(&self, expr: &Expr) -> EvalResult {
-        let result = eval(expr, &self.root_context());
+        let result = eval(expr, &self.context());
 
         // TODO: Collect garbage if needed
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -138,7 +138,7 @@ impl Drop for Evaluator {
             env.upgrade().map(|env| env.gc_sweep());
         });
 
-        // at this point, we should only have `root_env`
+        // at this point, we should only have `context.env`
         debug_assert_eq!(
             1,
             self.all_envs

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -48,7 +48,7 @@ pub fn eval(expr: &Expr, context: &EvalContext) -> EvalResult {
 
 pub struct Evaluator {
     all_envs: Rc<RefCell<Vec<Weak<Env>>>>,
-    root_env: Rc<Env>,
+    context: EvalContext,
 }
 
 impl Evaluator {
@@ -58,7 +58,10 @@ impl Evaluator {
 
         all_envs.borrow_mut().push(Rc::downgrade(&root_env));
 
-        Self { all_envs, root_env }
+        Self {
+            all_envs,
+            context: EvalContext { env: root_env },
+        }
     }
 
     pub fn with_builtin() -> Self {
@@ -68,7 +71,7 @@ impl Evaluator {
     }
 
     pub fn root_env(&self) -> &Rc<Env> {
-        return &self.root_env;
+        return &self.context.env;
     }
 
     pub fn root_context(&self) -> EvalContext {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -9,21 +9,34 @@ use crate::list::List;
 pub type EvalError = String;
 pub type EvalResult = Result<Expr, EvalError>;
 
-pub fn eval(expr: &Expr, env: &Rc<Env>) -> EvalResult {
+#[derive(Clone, Debug)]
+pub struct EvalContext {
+    pub env: Rc<Env>,
+}
+
+impl EvalContext {
+    pub fn derive_from(base: &EvalContext) -> Self {
+        Self {
+            env: Env::derive_from(&base.env),
+        }
+    }
+}
+
+pub fn eval(expr: &Expr, context: &EvalContext) -> EvalResult {
     use builtin::quote::{quasiquote, quote};
 
     match expr {
-        Expr::Sym(name, _) => match env.lookup(name) {
+        Expr::Sym(name, _) => match context.env.lookup(name) {
             Some(expr) => Ok(expr.clone()),
             None => Err(format!("Undefined symbol: {:?}", name)),
         },
         Expr::List(List::Cons(cons), _) => match cons.car.as_ref() {
-            Expr::Sym(text, _) if text == "quote" => quote(text, &cons.cdr, env),
-            Expr::Sym(text, _) if text == "quasiquote" => quasiquote(text, &cons.cdr, env),
+            Expr::Sym(text, _) if text == "quote" => quote(text, &cons.cdr, &context),
+            Expr::Sym(text, _) if text == "quasiquote" => quasiquote(text, &cons.cdr, &context),
             _ => {
-                if let Expr::Proc(proc, _) = eval(&cons.car, env)? {
+                if let Expr::Proc(proc, _) = eval(&cons.car, context)? {
                     let args = &cons.cdr;
-                    proc.invoke(args, env)
+                    proc.invoke(args, context)
                 } else {
                     Err(format!("{} does not evaluate to a callable.", cons.car))
                 }
@@ -58,8 +71,14 @@ impl Evaluator {
         return &self.root_env;
     }
 
+    pub fn root_context(&self) -> EvalContext {
+        EvalContext {
+            env: self.root_env().clone(),
+        }
+    }
+
     pub fn eval(&self, expr: &Expr) -> EvalResult {
-        let result = eval(expr, self.root_env());
+        let result = eval(expr, &self.root_context());
 
         // TODO: Collect garbage if needed
 

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -164,7 +164,7 @@ fn eval_macro(
     context: &EvalContext,
 ) -> EvalResult {
     let macro_name = macro_name.unwrap_or("macro");
-    let macro_context = EvalContext::derive_from(&context);
+    let macro_context = EvalContext::derive_from(context);
     let mut formal_args = formal_args.iter();
     let mut actual_args = actual_args.iter();
 

--- a/tests/builtin_tests.rs
+++ b/tests/builtin_tests.rs
@@ -24,7 +24,7 @@ fn test_cond() {
 #[test]
 fn test_define_variable() {
     let evaluator = Evaluator::with_builtin();
-    let outer_context = evaluator.root_context();
+    let outer_context = evaluator.context();
     let _ = eval_str_env("(define x 1)", &outer_context);
     assert_eq!(eval_str_env("x", &outer_context), "1");
     let _ = eval_str_env("(set! x 2)", &outer_context);
@@ -44,12 +44,12 @@ fn test_define_variable() {
 #[test]
 fn test_define_lambda() {
     let evaluator = Evaluator::with_builtin();
-    let context = evaluator.root_context();
+    let context = evaluator.context();
     let _ = eval_str_env(
         "(define (do-math x y) (num-subtract (num-multiply x 2) y))",
-        &context,
+        context,
     );
-    assert_eq!(eval_str_env("(do-math 50 1)", &context), "99");
+    assert_eq!(eval_str_env("(do-math 50 1)", context), "99");
 }
 
 #[test]
@@ -65,7 +65,7 @@ fn test_lambda() {
 #[test]
 fn test_set() {
     let evaluator = Evaluator::with_builtin();
-    let outer_context = evaluator.root_context();
+    let outer_context = evaluator.context();
     let inner_context = EvalContext::derive_from(&outer_context);
 
     let _ = eval_str_env("(define x 1)", &outer_context);

--- a/tests/builtin_tests.rs
+++ b/tests/builtin_tests.rs
@@ -1,8 +1,7 @@
 mod common;
 
 use common::{eval_str, eval_str_env};
-use rusp::env::Env;
-use rusp::eval::Evaluator;
+use rusp::eval::{EvalContext, Evaluator};
 
 #[test]
 fn test_car() {
@@ -25,32 +24,32 @@ fn test_cond() {
 #[test]
 fn test_define_variable() {
     let evaluator = Evaluator::with_builtin();
-    let outer_env = evaluator.root_env();
-    let _ = eval_str_env("(define x 1)", &outer_env);
-    assert_eq!(eval_str_env("x", &outer_env), "1");
-    let _ = eval_str_env("(set! x 2)", &outer_env);
-    assert_eq!(eval_str_env("x", &outer_env), "2");
+    let outer_context = evaluator.root_context();
+    let _ = eval_str_env("(define x 1)", &outer_context);
+    assert_eq!(eval_str_env("x", &outer_context), "1");
+    let _ = eval_str_env("(set! x 2)", &outer_context);
+    assert_eq!(eval_str_env("x", &outer_context), "2");
 
-    let inner_env = Env::derive_from(&outer_env);
+    let inner_context = EvalContext::derive_from(&outer_context);
 
-    let _ = eval_str_env("(define y 100)", &inner_env);
-    assert_eq!(eval_str_env("y", &inner_env), "100");
-    let _ = eval_str_env("(set! y 200)", &inner_env);
-    assert_eq!(eval_str_env("y", &inner_env), "200");
+    let _ = eval_str_env("(define y 100)", &inner_context);
+    assert_eq!(eval_str_env("y", &inner_context), "100");
+    let _ = eval_str_env("(set! y 200)", &inner_context);
+    assert_eq!(eval_str_env("y", &inner_context), "200");
 
-    assert_eq!(eval_str_env("x", &inner_env), "2");
-    assert!(eval_str_env("y", &outer_env).starts_with("Err:"));
+    assert_eq!(eval_str_env("x", &inner_context), "2");
+    assert!(eval_str_env("y", &outer_context).starts_with("Err:"));
 }
 
 #[test]
 fn test_define_lambda() {
     let evaluator = Evaluator::with_builtin();
-    let env = evaluator.root_env();
+    let context = evaluator.root_context();
     let _ = eval_str_env(
         "(define (do-math x y) (num-subtract (num-multiply x 2) y))",
-        env,
+        &context,
     );
-    assert_eq!(eval_str_env("(do-math 50 1)", &env), "99");
+    assert_eq!(eval_str_env("(do-math 50 1)", &context), "99");
 }
 
 #[test]
@@ -66,17 +65,17 @@ fn test_lambda() {
 #[test]
 fn test_set() {
     let evaluator = Evaluator::with_builtin();
-    let outer_env = evaluator.root_env();
-    let inner_env = Env::derive_from(&outer_env);
+    let outer_context = evaluator.root_context();
+    let inner_context = EvalContext::derive_from(&outer_context);
 
-    let _ = eval_str_env("(define x 1)", &outer_env);
-    assert_eq!(eval_str_env("x", &outer_env), "1");
-    let _ = eval_str_env("(set! x 2)", &outer_env);
-    assert_eq!(eval_str_env("x", &outer_env), "2");
+    let _ = eval_str_env("(define x 1)", &outer_context);
+    assert_eq!(eval_str_env("x", &outer_context), "1");
+    let _ = eval_str_env("(set! x 2)", &outer_context);
+    assert_eq!(eval_str_env("x", &outer_context), "2");
 
-    let _ = eval_str_env("(set! x 3)", &inner_env);
-    assert_eq!(eval_str_env("x", &inner_env), "3");
-    assert_eq!(eval_str_env("x", &outer_env), "3");
+    let _ = eval_str_env("(set! x 3)", &inner_context);
+    assert_eq!(eval_str_env("x", &inner_context), "3");
+    assert_eq!(eval_str_env("x", &outer_context), "3");
 }
 
 #[test]

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,16 +1,13 @@
-use std::rc::Rc;
-
-use rusp::env::Env;
-use rusp::eval::{eval, Evaluator};
+use rusp::eval::{eval, EvalContext, Evaluator};
 use rusp::lexer::Lexer;
 use rusp::parser::Parser;
 
 pub fn eval_str(text: &str) -> String {
     let evaluator = Evaluator::with_builtin();
-    eval_str_env(text, evaluator.root_env())
+    eval_str_env(text, &evaluator.root_context())
 }
 
-pub fn eval_str_env(text: &str, env: &Rc<Env>) -> String {
+pub fn eval_str_env(text: &str, context: &EvalContext) -> String {
     let mut tokens = Vec::new();
     let mut lexer = Lexer::new(text.chars());
     while let Some(token) = lexer
@@ -28,7 +25,7 @@ pub fn eval_str_env(text: &str, env: &Rc<Env>) -> String {
         panic!("Too many tokens: {}", text);
     }
 
-    match eval(&expr, env) {
+    match eval(&expr, context) {
         Ok(expr) => expr.to_string(),
         Err(error) => format!("Err: {}", error),
     }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -4,7 +4,7 @@ use rusp::parser::Parser;
 
 pub fn eval_str(text: &str) -> String {
     let evaluator = Evaluator::with_builtin();
-    eval_str_env(text, &evaluator.root_context())
+    eval_str_env(text, &evaluator.context())
 }
 
 pub fn eval_str_env(text: &str, context: &EvalContext) -> String {


### PR DESCRIPTION
As a prerequisite for tail-call optimisation, replacing `Rc<Env>` to `EvalContext` so that we can pass more information to `eval()`.